### PR TITLE
Approval flow for Compose Preview based Screenshot testing CI

### DIFF
--- a/.github/workflows/ci-screenshot.yml
+++ b/.github/workflows/ci-screenshot.yml
@@ -144,3 +144,14 @@ jobs:
             modules/**/build/reports/screenshotTest/preview/
             modules/**/build/outputs/screenshotTest-results/preview/*/
             modules/**/build/test-results/validate*ScreenshotTest/
+
+      - name: "Publish '🔔 Screenshot Test Results' check run."
+        if: ${{ success() || failure() }}
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        with:
+          check_name: '🔔 Screenshot Test Results'
+          comment_mode: off
+          report_individual_runs: true
+          action_fail_on_inconclusive: true
+          test_changes_limit: 0
+          junit_files: modules/**/build/test-results/validate*ScreenshotTest/TEST-*.xml

--- a/.github/workflows/ci-screenshot.yml
+++ b/.github/workflows/ci-screenshot.yml
@@ -147,11 +147,11 @@ jobs:
             modules/**/build/outputs/screenshotTest-results/preview/*/
             modules/**/build/test-results/validate*ScreenshotTest/
 
-      - name: "Publish '🔔 Screenshot Test Results' check run."
+      - name: "Publish '🔔 Test: Screenshot Results' check run."
         if: ${{ success() || failure() }}
         uses: EnricoMi/publish-unit-test-result-action@v2
         with:
-          check_name: '🔔 Screenshot Test Results'
+          check_name: '🔔 Test: Screenshot Results'
           comment_mode: off
           report_individual_runs: true
           action_fail_on_inconclusive: true

--- a/.github/workflows/ci-screenshot.yml
+++ b/.github/workflows/ci-screenshot.yml
@@ -99,6 +99,8 @@ jobs:
     permissions:
       # actions/checkout
       contents: read
+      # EnricoMi/publish-unit-test-result-action
+      checks: write
 
     defaults:
       run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,3 +48,4 @@ jobs:
     uses: ./.github/workflows/ci-screenshot.yml
     permissions:
       contents: read
+      checks: write

--- a/.github/workflows/screenshot-approve.yml
+++ b/.github/workflows/screenshot-approve.yml
@@ -1,0 +1,67 @@
+name: "Screenshot Tests Review"
+
+on:
+  # To work around https://github.com/github-community/community/discussions/19069, allow manual click.
+  workflow_dispatch:
+
+jobs:
+
+  approve:
+    name: "Approve Screenshot Test Results"
+    timeout-minutes: 1
+
+    permissions:
+      # read: rest.checks.listForRef
+      # write: rest.checks.update
+      checks: write
+      # rest.repos.createCommitStatus
+      statuses: write
+
+    runs-on: ubuntu-24.04
+    steps:
+
+      - name: "Update '🔔 Test: Screenshot Results' check run."
+        uses: actions/github-script@v7
+        env:
+          ref: ${{ github.ref }}
+          user: ${{ github.actor }}
+        with:
+          # language=javascript
+          script: |
+            // https://github.com/actions/toolkit/blob/main/packages/core/README.md
+
+            // https://docs.github.com/en/rest/checks/runs#list-check-runs-for-a-git-reference
+            const checks = await github.rest.checks.listForRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: process.env.ref,
+                check_name: "🔔 Test: Screenshot Results",
+            });
+            if (checks.data.total_count !== 1) {
+                console.log(checks);
+                core.setFailed(`There were ${checks.data.total_count} checks found, see logs.`);
+                return;
+            }
+            const check = checks.data.check_runs[0];
+            console.log(`Found check run: ${check.url}`);
+            if (check.conclusion !== "failure") {
+                console.log(checks);
+                core.warning(`Unsupported conclusion: ${check.conclusion}, maybe it was already approved?`);
+            }
+            // https://docs.github.com/en/rest/checks/runs#update-a-check-run
+            await github.rest.checks.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                check_run_id: check.id,
+                conclusion: "success",
+            });
+            // https://docs.github.com/en/rest/commits/statuses#create-a-commit-status
+            await github.rest.repos.createCommitStatus({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                sha: context.sha,
+                context: 'CI / Test: Screenshot Results Review',
+                description: `${process.env.user} approved.`,
+                state: "success",
+                target_url: check.html_url,
+            });

--- a/gradle/plugins/src/main/kotlin/net.twisterrob.astro.android-screenshots.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/net.twisterrob.astro.android-screenshots.gradle.kts
@@ -9,9 +9,11 @@
 
 import com.android.build.api.variant.HasHostTests
 import com.android.compose.screenshot.tasks.PreviewDiscoveryTask
+import com.android.compose.screenshot.tasks.PreviewScreenshotValidationTask
 import com.android.compose.screenshot.tasks.ScreenshotTestReportTask
 import net.twisterrob.astro.build.dsl.android
 import net.twisterrob.astro.build.dsl.androidComponents
+import net.twisterrob.astro.build.dsl.isCI
 import org.gradle.api.internal.exceptions.MarkedVerificationException
 import org.gradle.internal.logging.ConsoleRenderer
 import org.gradle.kotlin.dsl.support.serviceOf
@@ -26,6 +28,12 @@ plugins {
 
 dependencies {
 	"screenshotTestImplementation"(project(":component:test-base-screenshot"))
+}
+
+tasks.withType<PreviewScreenshotValidationTask>().configureEach {
+	// On CI we want it to "just pass", even if there's a failure.
+	// The CI will detect problems based on the JUnit XML report.
+	ignoreFailures = isCI.get()
 }
 
 android {


### PR DESCRIPTION
 * Fixes #36
 * Depends on #38
 * Followed by #41

## Scope

 * Make it possible to put required check on Compose Preview Screenshot Test CI
 * If screenshot tests fail, should be possible to accept

## Out of scope

 * Nice UI for viewing failures (see #41)
