### PR TITLE
Migrate from KGP 1.9.24 & Compose Compiler 1.5.14 to Kotlin 2.0 (2.0.0-RC3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@
 /modules/*/*/*/build/
 /modules/**/src/*/screenshotTest/reference/
 
+# Kotlin
+.kotlin/
+
 # Android
 local.properties
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,11 +8,6 @@ org.gradle.configuration-cache.problems=fail
 kotlin.stdlib.default.dependency=false
 # Workaround for https://youtrack.jetbrains.com/issue/KT-68297
 kotlin.daemon.jvmargs=-XX:-UseG1GC -XX:+UseParallelGC
-# Workaround for .kotlin folder in root, put it back where it was for now.
-# See https://youtrack.jetbrains.com/issue/KT-58223.
-# See https://kotlinlang.org/docs/whatsnew20.html#new-directory-for-kotlin-data-in-gradle-projects
-kotlin.project.persistent.dir=gradle/.kotlin
-kotlin.project.persistent.dir.gradle.disableWrite=true
 
 android.useAndroidX=true
 # https://developer.android.com/studio/preview/compose-screenshot-testing

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,6 +6,13 @@ org.gradle.configuration-cache=true
 org.gradle.configuration-cache.problems=fail
 
 kotlin.stdlib.default.dependency=false
+# Workaround for https://youtrack.jetbrains.com/issue/KT-68297
+kotlin.daemon.jvmargs=-XX:-UseG1GC -XX:+UseParallelGC
+# Workaround for .kotlin folder in root, put it back where it was for now.
+# See https://youtrack.jetbrains.com/issue/KT-58223.
+# See https://kotlinlang.org/docs/whatsnew20.html#new-directory-for-kotlin-data-in-gradle-projects
+kotlin.project.persistent.dir=.gradle/kotlin
+kotlin.project.persistent.dir.gradle.disableWrite=true
 
 android.useAndroidX=true
 # https://developer.android.com/studio/preview/compose-screenshot-testing

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ kotlin.daemon.jvmargs=-XX:-UseG1GC -XX:+UseParallelGC
 # Workaround for .kotlin folder in root, put it back where it was for now.
 # See https://youtrack.jetbrains.com/issue/KT-58223.
 # See https://kotlinlang.org/docs/whatsnew20.html#new-directory-for-kotlin-data-in-gradle-projects
-kotlin.project.persistent.dir=.gradle/kotlin
+kotlin.project.persistent.dir=gradle/.kotlin
 kotlin.project.persistent.dir.gradle.disableWrite=true
 
 android.useAndroidX=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,8 +6,7 @@ android-compileSdk = "34"
 android-minSdk = "34"
 android-targetSdk = "34"
 agp = "8.5.0-beta02"
-kotlin = "1.9.24"
-kotlin-composeCompiler = "1.5.14"
+kotlin = "2.0.0-RC3"
 
 detekt = "1.23.6"
 detekt-kode = "1.3.0"
@@ -31,7 +30,6 @@ androidx-viewmodelCompose = "2.8.0"
 
 [libraries]
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.ref = "kotlin" }
-kotlin-compose = { module = "androidx.compose.compiler:compiler", version.ref = "kotlin-composeCompiler" }
 detekt-rules-libraries = { module = "io.gitlab.arturbosch.detekt:detekt-rules-libraries", version.ref = "detekt" }
 detekt-rules-composeTwitter = { module = "io.nlopez.compose.rules:detekt", version.ref = "detekt-twitter" }
 detekt-rules-composeKode = { module = "ru.kode:detekt-rules-compose", version.ref = "detekt-kode" }
@@ -72,6 +70,7 @@ test-mockito-bom = { module = "org.mockito:mockito-bom", version.ref = "mockito"
 test-mockito-kotlin = { module = "org.mockito.kotlin:mockito-kotlin", version.ref = "mockito-kotlin" }
 
 [plugins]
+compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 android = { id = "com.android.application", version.ref = "agp" }

--- a/gradle/plugins/build.gradle.kts
+++ b/gradle/plugins/build.gradle.kts
@@ -7,6 +7,7 @@ dependencies {
 	api(libs.plugins.kotlin.asDependency())
 	api(libs.plugins.detekt.asDependency())
 	api(libs.plugins.android.asDependency())
+	api(libs.plugins.compose.asDependency())
 	api(libs.plugins.screenshot.asDependency())
 
 	// TODEL https://github.com/gradle/gradle/issues/15383

--- a/gradle/plugins/src/main/kotlin/net.twisterrob.astro.android-app.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/net.twisterrob.astro.android-app.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 android {
 	defaultConfig {
-		targetSdk = libs.versions.android.targetSdk.get().toInt()
+		targetSdk = libs.versions.android.targetSdk.map(String::toInt).get()
 	}
 	buildTypes {
 		debug {

--- a/gradle/plugins/src/main/kotlin/net/twisterrob/astro/build/android-base.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/net/twisterrob/astro/build/android-base.gradle.kts
@@ -23,9 +23,9 @@ android {
 		.replace(":", "_")
 		.plus("__")
 
-	compileSdk = libs.versions.android.compileSdk.get().toInt()
+	compileSdk = libs.versions.android.compileSdk.map(String::toInt).get()
 	defaultConfig {
-		minSdk = libs.versions.android.minSdk.get().toInt()
+		minSdk = libs.versions.android.minSdk.map(String::toInt).get()
 
 		vectorDrawables {
 			useSupportLibrary = true

--- a/gradle/plugins/src/main/kotlin/net/twisterrob/astro/build/android-base.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/net/twisterrob/astro/build/android-base.gradle.kts
@@ -6,6 +6,7 @@ import net.twisterrob.astro.build.dsl.libs
 plugins {
 	id("com.android.base")
 	id("org.jetbrains.kotlin.android")
+	id("org.jetbrains.kotlin.plugin.compose")
 	id("net.twisterrob.astro.build.kotlin")
 	id("net.twisterrob.astro.build.testing-android")
 	id("net.twisterrob.astro.build.detekt")
@@ -33,9 +34,6 @@ android {
 	}
 	buildFeatures {
 		compose = true
-	}
-	composeOptions {
-		kotlinCompilerExtensionVersion = libs.versions.kotlin.composeCompiler.get()
 	}
 	packaging {
 		resources {

--- a/gradle/plugins/src/main/kotlin/net/twisterrob/astro/build/kotlin.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/net/twisterrob/astro/build/kotlin.gradle.kts
@@ -17,7 +17,7 @@ dependencies {
 
 kotlin {
 	explicitApi = ExplicitApiMode.Strict
-	jvmToolchain(libs.versions.java.toolchain.get().toInt())
+	jvmToolchain(libs.versions.java.toolchain.map(String::toInt).get())
 }
 
 // TODO kotlin.target.compilerOptions { ... }

--- a/gradle/plugins/src/main/kotlin/net/twisterrob/astro/build/testing-android.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/net/twisterrob/astro/build/testing-android.gradle.kts
@@ -64,7 +64,7 @@ android {
 			}
 		}
 		managedDevices {
-			val minSdk = libs.versions.android.minSdk.get().toInt()
+			val minSdk = libs.versions.android.minSdk.map(String::toInt).get()
 			localDevices {
 				// ./gradlew pixel7ProApi34DebugAndroidTest
 				create("pixel7ProApi${minSdk}") {

--- a/gradle/plugins/src/main/kotlin/net/twisterrob/astro/build/testing/configureTestTask.kt
+++ b/gradle/plugins/src/main/kotlin/net/twisterrob/astro/build/testing/configureTestTask.kt
@@ -6,11 +6,12 @@ import net.twisterrob.astro.build.dsl.libs
 import org.gradle.api.Project
 import org.gradle.api.tasks.testing.Test
 import org.gradle.jvm.toolchain.JavaLanguageVersion
+import org.gradle.kotlin.dsl.assign
 
 internal fun Project.configureTestTask(task: Test) {
-	task.javaLauncher.set(javaToolchains.launcherFor {
-		languageVersion.set(JavaLanguageVersion.of(libs.versions.java.toolchainTest.get()))
-	})
+	task.javaLauncher = javaToolchains.launcherFor {
+		languageVersion = libs.versions.java.toolchainTest.map(JavaLanguageVersion::of)
+	}
 	task.ignoreFailures = isCI.get()
 	task.useJUnitPlatform()
 	task.systemProperties(junitPlatformProperties())

--- a/modules/domain/bazi-model/src/main/kotlin/net/twisterrob/astro/bazi/model/Phase.kt
+++ b/modules/domain/bazi-model/src/main/kotlin/net/twisterrob/astro/bazi/model/Phase.kt
@@ -12,7 +12,7 @@ import net.twisterrob.astro.bazi.model.Phase.Planet.Venus
  * https://en.wikipedia.org/wiki/Wuxing_(Chinese_philosophy)
  */
 @Suppress(
-	"UNINITIALIZED_ENUM_ENTRY", "SelfReferenceConstructorParameter",
+	"ConstructorParameterNaming",
 	"detekt.MagicNumber",
 )
 public enum class Phase(
@@ -28,14 +28,18 @@ public enum class Phase(
 	public val planet: Planet,
 
 	/**
-	 * Inter-livening (相生): Generating / Producing / Enhancing / Strengthening / Nurturing / Supporting.
+	 * Workaround for `UNINITIALIZED_ENUM_ENTRY` Kotlin compiler error.
+	 *
+	 * @see livening
 	 */
-	public val livening: Phase,
+	private val _livening: () -> Phase,
 
 	/**
-	 * Inter-conquering (相剋): Overcoming / Controlling / Weakening / Restraining / Reducing / Attacking.
+	 * Workaround for `UNINITIALIZED_ENUM_ENTRY` Kotlin compiler error.
+	 *
+	 * @see conquering
 	 */
-	public val conquering: Phase,
+	private val _conquering: () -> Phase,
 ) {
 
 	/**
@@ -44,8 +48,8 @@ public enum class Phase(
 	Mu(
 		order = 1,
 		planet = Jupiter,
-		livening = Huo, // Used to generate Fire.
-		conquering = Tu, // Wood grows on Earth and held it with its roots.
+		_livening = { Huo }, // Used to generate Fire.
+		_conquering = { Tu }, // Wood grows on Earth and held it with its roots.
 	),
 
 	/**
@@ -54,8 +58,8 @@ public enum class Phase(
 	Huo(
 		order = 2,
 		planet = Mars,
-		livening = Tu, // Produces ashes that is returned to the Earth.
-		conquering = Jin, // Fire will melt the Metal.
+		_livening = { Tu }, // Produces ashes that is returned to the Earth.
+		_conquering = { Jin }, // Fire will melt the Metal.
 	),
 
 	/**
@@ -64,8 +68,8 @@ public enum class Phase(
 	Tu(
 		order = 3,
 		planet = Saturn,
-		livening = Jin, // From the Earth, mines enable us to retrieve Metal.
-		conquering = Shui, // Earth absorbs the Water and thus stops the water flow.
+		_livening = { Jin }, // From the Earth, mines enable us to retrieve Metal.
+		_conquering = { Shui }, // Earth absorbs the Water and thus stops the water flow.
 	),
 
 	/**
@@ -74,8 +78,8 @@ public enum class Phase(
 	Jin(
 		order = 4,
 		planet = Venus,
-		livening = Shui, // Melts down to produce Water.
-		conquering = Mu, // Metal tools are used to cut Wood.
+		_livening = { Shui }, // Melts down to produce Water.
+		_conquering = { Mu }, // Metal tools are used to cut Wood.
 	),
 
 	/**
@@ -84,11 +88,21 @@ public enum class Phase(
 	Shui(
 		order = 5,
 		planet = Mercury,
-		livening = Mu, // Provides water for the Wood.
-		conquering = Huo, // Water is used to put out Fire.
+		_livening = { Mu }, // Provides water for the Wood.
+		_conquering = { Huo }, // Water is used to put out Fire.
 	),
 
 	;
+
+	/**
+	 * Inter-livening (相生): Generating / Producing / Enhancing / Strengthening / Nurturing / Supporting.
+	 */
+	public val livening: Phase get() = _livening()
+
+	/**
+	 * Inter-conquering (相剋): Overcoming / Controlling / Weakening / Restraining / Reducing / Attacking.
+	 */
+	public val conquering: Phase get() = _conquering()
 
 	public companion object;
 


### PR DESCRIPTION
Laziness is not related, just happened to be doing it :)

Research:
 * https://medium.com/@kacper.wojciechowski/kotlin-2-0-android-project-migration-guide-b1234fbbff65
 * https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-compiler.html
 * https://kotlinlang.org/docs/whatsnew-eap.html#new-directory-for-kotlin-data-in-gradle-projects  
   https://youtrack.jetbrains.com/issue/KT-58223  

Reported:
 * https://youtrack.jetbrains.com/issue/KT-68297/KGP-2.0-regression-JAVATOOLOPTIONS-is-not-considered-in-Kotlin-daemon-creation