### PR TITLE
Update to stable Kotlin 2.0.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ android-compileSdk = "34"
 android-minSdk = "34"
 android-targetSdk = "34"
 agp = "8.5.0-beta02"
-kotlin = "2.0.0-RC3"
+kotlin = "2.0.0"
 
 detekt = "1.23.6"
 detekt-kode = "1.3.0"


### PR DESCRIPTION
 * Follow-up on #42 

Of course 1 day after doing it, Kotlin stable just drops.

For some reason Renovate doesn't pick up the `kotlin` version, hoping after this bump it will. Will see on the next patch release.