### PR TITLE
Fix date picker picking previous day just past midnight

### DIFF
--- a/modules/screen/bazi/src/main/kotlin/net/twisterrob/astro/screen/bazi/DatePickerDialog.kt
+++ b/modules/screen/bazi/src/main/kotlin/net/twisterrob/astro/screen/bazi/DatePickerDialog.kt
@@ -28,7 +28,10 @@ internal fun DatePickerDialog(
 	onResetToToday: () -> Unit,
 ) {
 	val pickerState = rememberDatePickerState(
-		initialSelectedDateMillis = state.toInstant().toEpochMilli()
+		initialSelectedDateMillis = state
+			.withZoneSameLocal(ZoneOffset.UTC)
+			.toInstant()
+			.toEpochMilli(),
 	)
 	DatePickerDialog(
 		confirmButton = {

--- a/modules/screen/bazi/src/sharedTest/kotlin/net/twisterrob/astro/screen/bazi/DatePickerDialogUiTest.kt
+++ b/modules/screen/bazi/src/sharedTest/kotlin/net/twisterrob/astro/screen/bazi/DatePickerDialogUiTest.kt
@@ -16,6 +16,8 @@ import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyNoMoreInteractions
 import org.robolectric.annotation.Config
 import java.time.LocalDate
+import java.time.LocalTime
+import java.time.ZoneId
 import java.time.ZonedDateTime
 
 @RunWith(AndroidJUnit4::class)
@@ -57,6 +59,23 @@ class DatePickerDialogUiTest {
 		compose.onNodeWithText(string(R.string.screen_bazi__date_picker_dialog_ok)).performClick()
 
 		verify(mockListeners.onSelectDate).invoke(state.toLocalDate())
+		mockListeners.verifyNoMoreInteractions()
+	}
+
+	@Suppress("detekt.MagicNumber")
+	@Test
+	fun `ok selects the date given right past midnight`() {
+		val mockListeners = TestListeners()
+		val state = ZonedDateTime.of(
+			LocalDate.of(2025, 10, 6),
+			LocalTime.of(0, 30),
+			ZoneId.of("Europe/London"),
+		)
+		compose.setContent(state = state, listeners = mockListeners)
+
+		compose.onNodeWithText(string(R.string.screen_bazi__date_picker_dialog_ok)).performClick()
+
+		verify(mockListeners.onSelectDate).invoke(LocalDate.of(2025, 10, 6))
 		mockListeners.verifyNoMoreInteractions()
 	}
 


### PR DESCRIPTION
<img width="411" height="229" alt="image" src="https://github.com/user-attachments/assets/e74606ad-9b7d-4037-b866-1579679fabc9" />
<img width="384" height="348" alt="image" src="https://github.com/user-attachments/assets/5e1bc5bb-02ba-44d6-86dc-12896e14f162" />
<img width="404" height="108" alt="image" src="https://github.com/user-attachments/assets/5af5ef86-cf31-4952-ad1d-ee4c04a2f8dc" />
